### PR TITLE
Supports JSON files with comments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: main
+name: main-test
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,17 @@
 name: main
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [13.x]
+        node-version: [13.x, 12.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: main-test
+name: main
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [13.x, 12.x]
+        node-version: [13.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@actions/core": "^1.2.3",
+    "@actions/core": "^1.2.4",
     "@yarnpkg/lockfile": "^1.1.0",
     "concat-stream": "^2.0.0",
     "glob": "^7.1.6"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/node": "^13.7.7",
     "@types/yarnpkg__lockfile": "^1.1.3",
     "hard-source-webpack-plugin": "^0.13.1",
+    "strip-json-comments": "^3.1.1",
     "ts-loader": "^6.2.2",
     "typescript": "^3.8.3",
     "webpack": "^4.42.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import * as YarnLockFile from '@yarnpkg/lockfile'
 import { Doctor } from './doctor'
 import { loadTSModule } from './loadTSModule'
 
+const A: string = undefined
+
 function parseTSVersion(currentDir: string) {
   const yarnLockFilePath = path.resolve(currentDir, 'yarn.lock')
   const packageLockFile = path.resolve(currentDir, 'package-lock.json')

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,6 @@ import * as YarnLockFile from '@yarnpkg/lockfile'
 import { Doctor } from './doctor'
 import { loadTSModule } from './loadTSModule'
 
-const A: string = undefined
-
 function parseTSVersion(currentDir: string) {
   const yarnLockFilePath = path.resolve(currentDir, 'yarn.lock')
   const packageLockFile = path.resolve(currentDir, 'package-lock.json')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2509,6 +2509,11 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
+strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
 supports-color@6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.3.tgz#e844b4fa0820e206075445079130868f95bfca95"
-  integrity sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w==
+"@actions/core@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.4.tgz#96179dbf9f8d951dd74b40a0dbd5c22555d186ab"
+  integrity sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg==
 
 "@types/concat-stream@^1.6.0":
   version "1.6.0"


### PR DESCRIPTION
## 背景

`tsc init` で生成されるファイルはコメントを含むJSONファイルであること。

コメントを含むJSONは `parseJsonConfigFileContent` でパースできないこと。

## 行ったこと

`strip-json-comments` のインストール（コメント削除）

`parseJsonConfigFileContent` 付近を `try-catch` で囲む

Github ActionsのテストがPRでも走るように変更

## その他

probablyup さんの `@actions/core update` に依存しています

commit message が汚いので Squash か Rebase をお願いしたいです