### PR TITLE
Fix error when tsconfig.json contains comment

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -19,9 +19,12 @@ export class Doctor {
   }
 
   static fromConfigFile(configPath: string, ts: typeof _ts): Doctor {
-    const content = fs.readFileSync(configPath).toString();
+    const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile);
+    if (error) {
+      throw new Error(`Error while reading ${configPath}: ` + ts.flattenDiagnosticMessageText(error.messageText, '\n'))
+    }
     const parsed = ts.parseJsonConfigFileContent(
-        JSON.parse(content),
+        config,
         ts.sys,
         path.dirname(configPath)
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ async function main() {
 
     const tsVersion = parseTSVersion(currentDir)
     const remoteTS = await loadTSModule(tsVersion)
-  
+
     const doctor = Doctor.fromConfigFile(configPath, remoteTS)
     const diagnostics = doctor.getSemanticDiagnostics()
 
@@ -76,7 +76,7 @@ async function main() {
     }
 
   } catch (e) {
-    setFailed(e)
+    setFailed(e.toString())
   }
 }
 


### PR DESCRIPTION
- Got `(e || "").replace is not a function` #21, it is because catch (e) { setFailed(e) } passes Error object to `setFailed(message: string)` ([e is any in TS](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0-beta/#unknown-on-catch-clause-bindings))
- Then got SyntaxError: Unexpected token / in JSON at position ...
- Fix it by using `ts.readConfigFile()` instead of `fs.readFileSync()` (#9 solves same error but this PR uses builtin function from TS library and does not add any deps.